### PR TITLE
Fixed small typo in the try/except block around the random_envs import.

### DIFF
--- a/dropo/dropo.py
+++ b/dropo/dropo.py
@@ -166,10 +166,10 @@ class Dropo(object):
 	def pretty_print_bounds(self, phi):
 		assert (
 				self.sim_env is not None
-				and isinstance(self.sim_env.dynamics_indexes, dict)
+				and isinstance(self.sim_env.dyn_ind_to_name, dict)
 			   )
 
-		return '\n'.join([str(self.sim_env.dynamics_indexes[i])+':\t'+str(round(phi[i*2],5))+', '+str(round(phi[i*2+1],5)) for i in range(len(phi)//2)])
+		return '\n'.join([str(self.sim_env.dyn_ind_to_name[i])+':\t'+str(round(phi[i*2],5))+', '+str(round(phi[i*2+1],5)) for i in range(len(phi)//2)])
 
 
 

--- a/test_dropo.py
+++ b/test_dropo.py
@@ -22,7 +22,7 @@ import gym
 try:
     import random_envs
 except ImportError as e:
-    raise error.DependencyNotInstalled(f"Install random-envs from https://github.com/gabrieletiboni/random-envs to test DROPO on the OpenAI gym Hopper environment")
+    raise e.DependencyNotInstalled(f"Install random-envs from https://github.com/gabrieletiboni/random-envs to test DROPO on the OpenAI gym Hopper environment")
 from dropo import Dropo
 
 from utils import *


### PR DESCRIPTION
There is a small typo in the try/except block where the `ImportError` is captured into `e` but the script tries accessing it using variable `error`.