### PR TITLE
CMA optimizer misreference produces an error for now > 1

### DIFF
--- a/dropo/dropo.py
+++ b/dropo/dropo.py
@@ -829,7 +829,7 @@ class Dropo(object):
 			'tbpsa': ng.optimizers.TBPSA, # excellent for problems corrupted by noise, in particular overparameterized (neural) ones; very high num_workers ok).
 			'random': ng.optimizers.RandomSearch, # the classical random search baseline; don’t use softmax with this optimizer.
 			'meta': ng.optimizers.NGOpt, # “meta”-optimizer which adapts to the provided settings (budget, number of workers, parametrization) and should therefore be a good default.
-			'cma': ng.optimizers.CMA # CMA-ES (https://en.wikipedia.org/wiki/CMA-ES)
+			'cma': ng.optimizers._CMA # CMA-ES (https://en.wikipedia.org/wiki/CMA-ES)
 		}
 
 		if opt_string not in opts:


### PR DESCRIPTION
Attempting to run DROPO with more than a single worker (`now` > 1) produces the following error:
```
Traceback (most recent call last):
  File "test_dropo.py", line 132, in <module>
    main()
  File "test_dropo.py", line 64, in main
    learned_epsilon) = dropo.optimize_dynamics_distribution(opt=args.opt,
  File "/home/can/Repositories/dropo/dropo/dropo.py", line 304, in optimize_dynamics_distribution
    while len(X) < optim.es.popsize:
AttributeError: 'CMA' object has no attribute 'es'
```

The proposed change from `ng.optimizers.CMA` to `ng.optimizers._CMA` fixes the error and allows the execution to complete successfully.

`ng.optimizers._CMA` has the following `es` property defined:
```py
@property
def es(self) -> tp.Any
```
whereas `ng.optimizers.CMA` does not.